### PR TITLE
Don't show title by default

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,58 +1,80 @@
 ---
-import '../styles/global.css'
-import Sidebar from '../components/Sidebar.astro';
-import ThemeToggle from '../components/ThemeToggle.astro';
+import "../styles/global.css";
+import Sidebar from "../components/Sidebar.astro";
+import ThemeToggle from "../components/ThemeToggle.astro";
 
 interface Props {
-  title: string;
-  description?: string;
-  pageDescription?: string;
-  showTitle?: boolean;
+    title: string;
+    description?: string;
+    pageDescription?: string;
+    showTitle?: boolean;
 }
 
-const { title, description = 'UIUC CS Wiki - A student-maintained guide to CS courses and resources', pageDescription, showTitle = true } = Astro.props;
+const {
+    title,
+    description = "UIUC CS Wiki - A student-maintained guide to CS courses and resources",
+    pageDescription,
+    showTitle = false,
+} = Astro.props;
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content={description} />
-  <link rel="icon" href="/favicon.ico?v=2" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Montserrat:wght@600;700;800&family=Source+Sans+3:wght@400;500;600&display=swap" rel="stylesheet" />
-  <title>{title} | UIUC CS Wiki</title>
-  <!-- Prevent flash of wrong theme -->
-  <script is:inline>
-    const theme = localStorage.getItem('theme') || 
-      (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-    if (theme === 'dark') document.documentElement.classList.add('dark');
-  </script>
-</head>
-<body class="bg-wiki-bg text-wiki-text antialiased">
-  <div class="flex min-h-screen">
-    <!-- Sidebar -->
-    <Sidebar />
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="description" content={description} />
+        <link rel="icon" href="/favicon.ico?v=2" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&family=Montserrat:wght@600;700;800&family=Source+Sans+3:wght@400;500;600&display=swap"
+            rel="stylesheet"
+        />
+        <title>{title} | UIUC CS Wiki</title>
+        <!-- Prevent flash of wrong theme -->
+        <script is:inline>
+            const theme =
+                localStorage.getItem("theme") ||
+                (window.matchMedia("(prefers-color-scheme: dark)").matches
+                    ? "dark"
+                    : "light");
+            if (theme === "dark")
+                document.documentElement.classList.add("dark");
+        </script>
+    </head>
+    <body class="bg-wiki-bg text-wiki-text antialiased">
+        <div class="flex min-h-screen">
+            <!-- Sidebar -->
+            <Sidebar />
 
-    <!-- Main Content -->
-    <main class="ml-72 flex-1">
-      <!-- Top bar with theme toggle -->
-      <div class="sticky top-0 z-10 flex justify-end border-b border-wiki-border bg-wiki-bg/80 backdrop-blur-sm px-8 py-3">
-        <ThemeToggle />
-      </div>
-      
-      <div class="mx-auto max-w-4xl px-8 py-8">
-        {showTitle && (
-          <div class="mb-8">
-            <h1 class="text-4xl font-display font-bold text-wiki-text mb-2">{title}</h1>
-            {pageDescription && <p class="text-lg text-wiki-muted">{pageDescription}</p>}
-          </div>
-        )}
-        <slot />
-      </div>
-    </main>
-  </div>
-</body>
+            <!-- Main Content -->
+            <main class="ml-72 flex-1">
+                <!-- Top bar with theme toggle -->
+                <div
+                    class="sticky top-0 z-10 flex justify-end border-b border-wiki-border bg-wiki-bg/80 backdrop-blur-sm px-8 py-3"
+                >
+                    <ThemeToggle />
+                </div>
+
+                <div class="mx-auto max-w-4xl px-8 py-8">
+                    {
+                        showTitle && (
+                            <div class="mb-8">
+                                <h1 class="text-4xl font-display font-bold text-wiki-text mb-2">
+                                    {title}
+                                </h1>
+                                {pageDescription && (
+                                    <p class="text-lg text-wiki-muted">
+                                        {pageDescription}
+                                    </p>
+                                )}
+                            </div>
+                        )
+                    }
+                    <slot />
+                </div>
+            </main>
+        </div>
+    </body>
 </html>

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -1,22 +1,26 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import { getCollection } from 'astro:content';
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
-  const guides = await getCollection('guides');
-  
-  return guides.map(guide => ({
-    params: { slug: guide.slug },
-    props: { guide },
-  }));
+    const guides = await getCollection("guides");
+
+    return guides.map((guide) => ({
+        params: { slug: guide.slug },
+        props: { guide },
+    }));
 }
 
 const { guide } = Astro.props;
 const { Content } = await guide.render();
 ---
 
-<BaseLayout title={guide.data.title} pageDescription={guide.data.description}>
-  <div class="prose max-w-none">
-    <Content />
-  </div>
+<BaseLayout
+    title={guide.data.title}
+    pageDescription={guide.data.description}
+    showTitle={true}
+>
+    <div class="prose max-w-none">
+        <Content />
+    </div>
 </BaseLayout>


### PR DESCRIPTION
Restores original behavior for all other pages, while allowing it to be sensical for guide pages