### PR TITLE
made revision to confusing line in description of cs421

### DIFF
--- a/src/content/classes/CS/cs421.mdx
+++ b/src/content/classes/CS/cs421.mdx
@@ -12,7 +12,7 @@ tags: ['core']
 
 This course is the core programming language course in the CS major. The class is comprised on in-person lectures, quizzes, MPs, Labs, GAs, and exams. Exact course structure will vary depending on the instructor. Professor Elsa Gunter has traditionally taught this course in OCaml, and Professor Mattox Beckman has traditionally taught this course in Haskell.
 
-A small handful of CS + X majors are required not required to take this course.
+A small handful of CS + X majors are not required to take this course.
 
 ## Topics Covered
 


### PR DESCRIPTION
## Description

<!-- Briefly describe what you added or changed -->
Changed line in CS421 Guide
Original: A small handful of CS + X majors are required not required to take this course.
Revised: A small handful of CS + X majors are not required to take this course.

## Type of Change

- [X] Grammar fix

## Checklist

- [X] I have tested my changes locally with `yarn dev`
- [X] Links and images render correctly
- [X] Content follows the [style guidelines](../CONTRIBUTING.md#style-guidelines)
